### PR TITLE
Fixes counting 2x `downloaded ok` for cdnld_f21

### DIFF
--- a/static_flow/flow_include.sh
+++ b/static_flow/flow_include.sh
@@ -302,7 +302,7 @@ fi
   totcveille="${tot}"
 
   if [ "${sarra_py_version:0:1}" == "3" ]; then
-      countthem "`grep -a 'downloaded ok' $LOGDIR/${LGPFX}subscribe_cdnld_f21_*.log | wc -l`"
+      countthem "`grep -a 'after_work downloaded ok' $LOGDIR/${LGPFX}subscribe_cdnld_f21_*.log | wc -l`"
   else
       countthem "`grep -a '\[INFO\] file_log downloaded ' $LOGDIR/${LGPFX}subscribe_cdnld_f21_*.log | wc -l`"
   fi


### PR DESCRIPTION
See description of problem here: https://github.com/MetPX/sr_insects/commit/d4bd05c9028dad0c1eb0baf315c9407069d2c7b7

Example: https://github.com/MetPX/sarracenia/actions/runs/3092410800/jobs/5003824091 

<pre>
test 1 success: Log perms confirmed
                 | content of subdirs of /home/runner/sarra_devdocroot |
test 2 success: compare contents of downloaded_by_sub_amqp and downloaded_by_sub_cp are the same
test 3 success: compare contents of downloaded_by_sub_cp and downloaded_by_sub_rabbitmqtt are the same
test 4 success: compare contents of downloaded_by_sub_rabbitmqtt and downloaded_by_sub_u are the same
test 5 success: compare contents of downloaded_by_sub_u and posted_by_shim are the same
test 6 success: compare contents of downloaded_by_sub_amqp and linked_by_shim are the same
test 7 success: compare contents of posted_by_shim and sent_by_tsource2send are the same
test 8 success: compare contents of downloaded_by_sub_amqp and cfile are the same
test 9 success: compare contents of cfile and cfr are the same
broker state:
                 | dd.weather routing |
test 10 success: post	 count of posted files (1111) should be same those in the static data directory	 (1111)
test 11 success: post	 count of rejected files (10) should be same those in the static data directory	 (10)
test 12 success: post	 (1111) t_dd1 should have the same number of items as t_dd2	 (1111)
test 13 success: sarra	 (2222) should receive the same number of items as both post	 (2222)
test 14 success: sarra	 (1111) should publish the same number of items as one post	 (1111)
test 15 success: sarra	 (1111) should winnow the same number of items as one post	 (1111)
test 16 success: subscribe	 (1111) should rx the same number of items as sarra published	 (1111)
                 | watch      routing |
test 17 success: watch		 (1111) should be the same as subscribe amqp_f30		  (1111)
test 18 success: sender		 (1111) should publish the same number of items as watch  (1111)
test 19 success: rabbitmqtt		 (1111) should download same number of items as watch  (1111)
test 20 success: subscribe u_sftp_f[60](https://github.com/MetPX/sarracenia/actions/runs/3092410800/jobs/5003824091#step:6:61) (1111) should download same number of items as sender (1111)
test 21 success: subscribe cp_f[61](https://github.com/MetPX/sarracenia/actions/runs/3092410800/jobs/5003824091#step:6:62)	 (1111) should download same number of items as sender (1111)
                 | poll       routing |
test 22 success: poll sftp_f[62](https://github.com/MetPX/sarracenia/actions/runs/3092410800/jobs/5003824091#step:6:63)	 (1111) should publish same number of items of sender sent	 (1111)
test 23 success: subscribe q_f71	 (1111) should download same number of items as poll test1_f62 (1111)
                 | flow_post  routing |
test 24 success: post test2_f61	 (1111) should have the same number of items of sender 	 (1111)
test 25 success: subscribe ftp_f70	 (1111) should have the same number of items as post test2_f61 (1111)
test 26 success: post test2_f61	 (1111) should have about half the number of items as shim_f[63](https://github.com/MetPX/sarracenia/actions/runs/3092410800/jobs/5003824091#step:6:64)	 (2222)
                 | py infos   routing |
test 27 success: 0 messages received that we don't know what happened.
                 | C          routing |
test 28 success: cpost both pelles should post the same number of messages (1111) (1111)
<b>test 29 FAILURE: cdnld_f21 subscribe downloaded (2222) the same number of files that was published by both van_14 and van_15 (1111)</b>
test 30 FAILURE: veille_f34 should post as many files (1111) as subscribe cdnld_f21 downloaded (2222)
test 31 success: veille_f34 should post as many files (1111) as subscribe cfile_f44 downloaded (1111)
test 32 success: 0 there should be no unacknowledged messages left, but there are 0
test 33 success: 0 there should be no messages ready to be consumed but there are 0
Overall 31 of 33 passed (sample size: 1111) !
</pre>