### PR TITLE
reflect numeric dangerWillRobinson

### DIFF
--- a/flow_utils.sh
+++ b/flow_utils.sh
@@ -76,11 +76,14 @@ function sr_action {
     
     echo $msg
     if [ "${sarra_py_version:0:1}" == "3" ]; then
+
+	count="`sr3 status | grep stop | wc -l`"
+
         if [ "$SARRA_LIB" ]; then
-            ${SARRA_LIB}/sr3.py --dangerWillRobinson $action $files 
+            ${SARRA_LIB}/sr3.py --dangerWillRobinson $count $action $files 
         else
             echo sr3 $action $files
-            sr3 --dangerWillRobinson $action $files 
+            sr3 --dangerWillRobinson $count $action $files 
         fi
     else
         if [ "$SARRAC_LIB" ]; then


### PR DESCRIPTION
This change is needed to match this other pull.:

https://github.com/MetPX/sarracenia/pull/831

It makes the cleanup jobs in sr_insects set the numeric argument for --dangerWillRobinson option properly ...

original issue:

https://github.com/MetPX/sarracenia/issues/827

