### PR TITLE
getting redhat enterprise 8 to pass the flow tests.

### DIFF
--- a/flakey_broker/flow_check.sh
+++ b/flakey_broker/flow_check.sh
@@ -92,7 +92,7 @@ function checktree {
 
   report=${SUMDIR}/`basename ${tree}`.txt
   #if [ ! -f ${report} ]; then
-  (cd ${tree}; find . \! -type d | xargs md5sum ) > ${report}
+  (cd ${tree}; find . \! -type d | xargs md5sum ) | sort > ${report}
   #fi
 
 }

--- a/flakey_broker/flow_check.sh
+++ b/flakey_broker/flow_check.sh
@@ -196,7 +196,7 @@ echo "                 | dd.weather routing |"
 
 if [ ! "${SKIP_KNOWN_BAD}" ]; then
     expected_xattr_cnt=2242
-    src_xattr_cnt="`find ${SAMPLEDATA} -type f | xargs xattr -l|wc -l`"
+    src_xattr_cnt="`find ${SAMPLEDATA} -type f | xargs xattr -l|  grep ': user.sr_.*: '| wc -l`"
     calcres ${src_xattr_cnt} ${expected_xattr_cnt} "expected ${expected_xattr_cnt} number of extended attributes in source tree ${src_xattr_cnt}"
 fi
 

--- a/no_mirror/config/post/t_dd1_f00.conf
+++ b/no_mirror/config/post/t_dd1_f00.conf
@@ -2,7 +2,7 @@
 post_broker ${MQP}://tfeed@${FLOWBROKER}/
 post_base_url http://localhost:8090
 post_base_dir ${SAMPLEDATA}
-post_exchange xsarra
+post_exchange xs_tsource_lala
 post_topic_prefix v03.post
 sum s
 

--- a/no_mirror/config/post/t_dd2_f00.conf
+++ b/no_mirror/config/post/t_dd2_f00.conf
@@ -2,7 +2,7 @@
 post_broker ${MQP}://tfeed@${FLOWBROKER}/
 post_base_url http://localhost:8090
 post_base_dir ${SAMPLEDATA}
-post_exchange xsarra
+post_exchange xs_tsource_lala
 post_topic_prefix v03.post
 sum s
 

--- a/no_mirror/config/report/tsarra_f20.conf
+++ b/no_mirror/config/report/tsarra_f20.conf
@@ -1,5 +1,5 @@
 broker ${MQP}://tfeed@${FLOWBROKER}/
-exchange xsarra
+exchange xs_tsource_lala
 topic_prefix v02.post
 
 # expire should be long enough to survive longest expected interruption.

--- a/no_mirror/config/sarra/download_f20.conf
+++ b/no_mirror/config/sarra/download_f20.conf
@@ -63,7 +63,7 @@ events create,modify
 # If you put this back in, all the posts will fail.  This is new desired behaviour,
 # as per issue #294
 #on_post post_long_flow.py
-directory ${TESTDOCROOT}/sarra_download_f20
+directory ${TESTDOCROOT}/sarra_download_f20/${SOURCE}
 
 accept .*
 

--- a/no_mirror/config/sarra/download_f20.conf
+++ b/no_mirror/config/sarra/download_f20.conf
@@ -20,8 +20,10 @@
 # of setup.sh
 
 broker ${MQP}://tfeed@${FLOWBROKER}/
-exchange xsarra
+exchange xs_tsource_lala
 topic_prefix v03.post
+
+sourceFromExchange on
 
 heartbeat 60
 

--- a/no_mirror/config/sender/tsource2send_f50.conf
+++ b/no_mirror/config/sender/tsource2send_f50.conf
@@ -4,7 +4,7 @@
 # 
 
 broker ${MQP}://tfeed@${FLOWBROKER}
-exchange xsarra
+exchange xs_tsource_lala
 
 debug
 topic_prefix v03.post

--- a/no_mirror/flow_check.sh
+++ b/no_mirror/flow_check.sh
@@ -150,7 +150,7 @@ checktree ${testdocroot}/recd_by_srpoll_test1
 checktree ${testdocroot}/cfile
 checktree ${testdocroot}/cfr
 
-checktree ${testdocroot}/sarra_download_f20
+checktree ${testdocroot}/sarra_download_f20/tsource
 checktree ${testdocroot}/sent_by_tsource2send/deeper/than/flat/sender
 
 if [[ -z "$skip_summaries" ]]; then
@@ -193,7 +193,7 @@ printf "\t\tTEST RESULTS\n\n"
 logPermCheck
 
 echo "                 | content of subdirs of ${testdocroot} |"
-comparetree sarra_download_f20 sender
+comparetree tsource sender
 
 comparetree downloaded_by_sub_amqp downloaded_by_sub_cp
 comparetree downloaded_by_sub_cp downloaded_by_sub_rabbitmqtt

--- a/no_mirror/flow_check.sh
+++ b/no_mirror/flow_check.sh
@@ -89,7 +89,7 @@ function checktree {
 
   report=${SUMDIR}/`basename ${tree}`.txt
   #if [ ! -f ${report} ]; then
-  (cd ${tree}; find . \! -type d | xargs md5sum ) > ${report}
+  (cd ${tree}; find . \! -type d | xargs md5sum ) |sort > ${report}
   #fi
 
 }

--- a/restart_server/flow_check.sh
+++ b/restart_server/flow_check.sh
@@ -91,7 +91,7 @@ function checktree {
 
   report=${SUMDIR}/`basename ${tree}`.txt
   #if [ ! -f ${report} ]; then
-  (cd ${tree}; find . \! -type d | xargs md5sum ) > ${report}
+  (cd ${tree}; find . \! -type d | xargs md5sum ) | sort > ${report}
   #fi
 
 }
@@ -194,7 +194,7 @@ t4=$(( ${totfileamqp}*4 ))
 
 echo "                 | dd.weather routing |"
 expected_xattr_cnt=2242
-src_xattr_cnt="`find ${SAMPLEDATA} -type f | xargs xattr -l|wc -l`"
+src_xattr_cnt="`find ${SAMPLEDATA} -type f | xargs xattr -l| grep ': user.sr_.*: '| wc -l`"
 calcres ${src_xattr_cnt} ${expected_xattr_cnt} "expected ${expected_xattr_cnt} number of extended attributes in source tree ${src_xattr_cnt}"
 
 

--- a/static_flow/flow_check.sh
+++ b/static_flow/flow_check.sh
@@ -89,7 +89,7 @@ function checktree {
 
   report=${SUMDIR}/`basename ${tree}`.txt
   #if [ ! -f ${report} ]; then
-  (cd ${tree}; find . \! -type d | xargs md5sum ) > ${report}
+  (cd ${tree}; find . \! -type d | xargs md5sum ) | sort > ${report}
   #fi
 
 }


### PR DESCRIPTION
* sort checksums of tree because they come out in a different order, creating fake failures.
* redhat has selinux file attributes for every file, so have to ignore them when looking a the extended attributes set by sarracenia.

