### PR TITLE
comment out failing test to avoid bogus failures

### DIFF
--- a/static_flow/flow_maint_test.sh
+++ b/static_flow/flow_maint_test.sh
@@ -57,7 +57,7 @@ if [ ! -d "${pyexamples}" ]; then
     fi
 fi
 
-printf "running the python example from ($pyexamples}\n\n"
+printf "running the python example from (${pyexamples})\n\n"
 echo " running: python3 ${pyexamples}/moth_api_producer.py amqp://bunnymaster:${adminpw}@localhost  "
 python3 ${pyexamples}/moth_api_producer.py amqp://bunnymaster:"${adminpw}"@localhost
 
@@ -77,7 +77,7 @@ posted_message_count="`rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -
 
 printf "count of messages queued is: ${posted_message_count}\n\n" 
 
-calcres "${posted_message_count}" 1 "moth_api_producer.py should have posted 1 message"
+#calcres "${posted_message_count}" 1 "moth_api_producer.py should have posted 1 message"
 
 sr3 stop
 


### PR DESCRIPTION
This is for issue #46. Bigger discussion there. problem is need to declare a consumer so the queue snags the published announcement. currently the producer works, publishing the message, but the method used to check that needs for a queue to be bound and waiting for it. that's missing. a bit of work to fix.