### PR TITLE
must not request invalid configurations anymore

### DIFF
--- a/am_flow/flow_cleanup.sh
+++ b/am_flow/flow_cleanup.sh
@@ -7,7 +7,7 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 echo remove x attributes added by post then calculating checksums. in ${SAMPLEDATA}
@@ -82,7 +82,7 @@ for exchange in $exchanges_to_delete ; do
    rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -f tsv delete exchange name=${exchange} >>$flowlogcleanup 2>&1
 done
 
-flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; ls */*f[0-9][0-9].inc 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; 2>/dev/null`"
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 sr_action "Removing flow configs..." remove " " ">> $flowlogcleanup 2>\\&1" "$flow_configs"

--- a/dynamic_flow/flow_cleanup.sh
+++ b/dynamic_flow/flow_cleanup.sh
@@ -7,7 +7,12 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+
+if [ "${sarra_py_version:0:1}" == "3" ]; then
+    flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+else
+    flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+fi
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 # Stopping sr components

--- a/dynamic_flow/flow_setup.sh
+++ b/dynamic_flow/flow_setup.sh
@@ -182,10 +182,6 @@ fi
 # then it will hang.  going sequentially means the other component never gets launched, so it's a deadlock
 # and just hangs forever.
 
-#flow_configs="audit/ `cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf | grep -v '^post'; ls poll/pulse.conf`"
-#sr_action "Starting up all components..." start " " ">> $flowsetuplog 2>\\&1" "$flow_configs"
-#echo "Done."
-
 # In the replacement below, using just plain *sr start*  all the processes are launched 
 # at once, and reaped as they finish. so no deadlocks occur.
 # 

--- a/flakey_broker/flow_cleanup.sh
+++ b/flakey_broker/flow_cleanup.sh
@@ -7,7 +7,12 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+if [ ${sarra_py_version:0:1} == '3' ]; then
+    flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+else
+    flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+fi 
+
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 echo remove x attributes added by post then calculating checksums. in ${SAMPLEDATA}
@@ -106,7 +111,8 @@ for exchange in $exchanges_to_delete ; do
    rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -f tsv delete exchange name=${exchange} >>$flowlogcleanup 2>&1
 done
 
-flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; ls */*f[0-9][0-9].inc 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+#flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; ls */*f[0-9][0-9].inc 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 sr_action "Removing flow configs..." remove " " ">> $flowlogcleanup 2>\\&1" "$flow_configs"

--- a/no_mirror/flow_cleanup.sh
+++ b/no_mirror/flow_cleanup.sh
@@ -7,7 +7,12 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+
+if [ "${sarra_py_version:0:1}" == "3" ]; then
+    flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+else
+    flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+fi
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 echo remove x attributes added by post then calculating checksums. in ${SAMPLEDATA}

--- a/partitioned_flow/flow_cleanup.sh
+++ b/partitioned_flow/flow_cleanup.sh
@@ -7,7 +7,7 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 echo remove x attributes added by post then calculating checksums. in ${SAMPLEDATA}

--- a/restart_server/flow_cleanup.sh
+++ b/restart_server/flow_cleanup.sh
@@ -7,7 +7,12 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+
+if [ ${sarra_py_version:0:1} == '3' ]; then
+    flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+else
+    flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+fi
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 echo remove x attributes added by post then calculating checksums. in ${SAMPLEDATA}

--- a/static_flow/flow_cleanup.sh
+++ b/static_flow/flow_cleanup.sh
@@ -7,7 +7,12 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+
+if [ "${sarra_py_version:0:1}" == "3" ]; then
+    flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+else
+    flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+fi
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 echo remove x attributes added by post then calculating checksums. in ${SAMPLEDATA}
@@ -107,7 +112,8 @@ for exchange in $exchanges_to_delete ; do
    rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -f tsv delete exchange name=${exchange} >>$flowlogcleanup 2>&1
 done
 
-flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; ls */*f[0-9][0-9].inc 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+#flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; ls */*f[0-9][0-9].inc 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+flow_configs="`cd ${SR_TEST_CONFIGS}; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 sr_action "Removing flow configs..." remove " " ">> $flowlogcleanup 2>\\&1" "$flow_configs"

--- a/trans3_flow/flow_cleanup.sh
+++ b/trans3_flow/flow_cleanup.sh
@@ -7,7 +7,7 @@ export TESTDIR="`pwd`"
 
 flowlogcleanup="$LOGDIR/flowcleanup_f99.log"
 touch $flowlogcleanup
-flow_configs="audit/ `cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
+flow_configs="`cd $CONFDIR; ls */*f[0-9][0-9].conf 2>/dev/null; ls poll/pulse.conf 2>/dev/null`"
 flow_configs="`echo ${flow_configs} | tr '\n' ' '`"
 
 if [ `find ${SAMPLEDATA} -type f | xargs xattr -l|wc -l` ]; then 


### PR DESCRIPTION
in sarracenia issue 1159, validation of configurations requested is done, and if any one is bad, the command aborts.  Until that time we specified audit/ and sometimes include files, which aren't complete flow configurations.  with the new validations, those get rejected, the commands abort, and the flow tests fail.

Sarracenia issue: https://github.com/MetPX/sarracenia/issues/1159

This change checks for version 3 and ensures that no invalid configurations are specified for flow tests.
Without these changes the 1159 checks will fail.
