### PR TITLE
Issue37 - Make AM flow tests more compatible for different hosts

### DIFF
--- a/am_flow/config/flow/amserver-flow_f01.conf
+++ b/am_flow/config/flow/amserver-flow_f01.conf
@@ -11,6 +11,7 @@ download on
 # directory /datalocal/am/bulletins/
 destination am://${FLOWBROKER}:5005
 
+post_format v03
 post_topicPrefix v03.post
 post_broker ${MQP}://tfeed@${FLOWBROKER}
 post_exchange xpublic

--- a/am_flow/config/sarra/get_from-watch_f02.conf
+++ b/am_flow/config/sarra/get_from-watch_f02.conf
@@ -46,7 +46,9 @@ acceptUnmatched False
 
 post_broker ${MQP}://tsource@${FLOWBROKER}/
 post_exchange xs_tsource_am
-post_baseUrl file://home/home/sarra/sarra_devdocroot/bulletins_to_download
+post_baseUrl file:/${TESTDOCROOT}/bulletins_to_download
 post_baseDir /
+post_topicPrefix v03.post
+post_format v03
 
 logLevel debug

--- a/am_flow/config/sarra/get_from-watch_f02.conf
+++ b/am_flow/config/sarra/get_from-watch_f02.conf
@@ -17,7 +17,7 @@ prefetch 10
 
 # what to do with product
 
-mirror True
+mirror False
 timeCopy False
 delete False
 
@@ -32,7 +32,7 @@ permDefault 664
 
 # directories
 
-directory ${TESTDOCROOT}/bulletins_to_download/${YYYYMMDD}
+directory ${TESTDOCROOT}/bulletins_to_download/${YYYYMMDD}/${T1}${T2}/${CCCC}/${HH}
 
 # These bulletins are too long for AM to handle transferring
 reject .*FP/.*
@@ -46,7 +46,7 @@ acceptUnmatched False
 
 post_broker ${MQP}://tsource@${FLOWBROKER}/
 post_exchange xs_tsource_am
-post_baseUrl file:/${TESTDOCROOT}/bulletins_to_download
+post_baseUrl file:///
 post_baseDir /
 post_topicPrefix v03.post
 post_format v03

--- a/am_flow/config/watch/watch-dir_f03.conf
+++ b/am_flow/config/watch/watch-dir_f03.conf
@@ -1,8 +1,9 @@
 post_topic_prefix v03.post
+post_format v03
 
 post_broker ${MQP}://tfeed@${FLOWBROKER}/
 post_exchange xs_tfeed_am
-post_baseUrl file://home/home/sarra/sarra_devdocroot/bulletins_to_post/bulletins
+post_baseUrl file://${TESTDOCROOT}
 post_baseDir /
 
 

--- a/am_flow/config/watch/watch-dir_f03.conf
+++ b/am_flow/config/watch/watch-dir_f03.conf
@@ -3,7 +3,7 @@ post_format v03
 
 post_broker ${MQP}://tfeed@${FLOWBROKER}/
 post_exchange xs_tfeed_am
-post_baseUrl file://${TESTDOCROOT}
+post_baseUrl file:///
 post_baseDir /
 
 
@@ -17,7 +17,8 @@ fileEvents create
 #caching False
 #recursive True
 
-strip 5
+# Inconsistent between home dirs.. need to remove
+#strip 5
 reject .*tmp.*
 accept .*
 

--- a/am_flow/flow_check.sh
+++ b/am_flow/flow_check.sh
@@ -243,11 +243,11 @@ calcres "${totsentx}" "${totflowp}" "sender\t\t (${totsentx}) should post same n
 echo "                 | Downloaded files |"
 calcres "${totsard}" "${totflowd}" "${LGPFX}sarra\t (${totsard}) should download same number of files as ${LGPFX}flow downloads\t (${totflowd})"
 calcres "${totflowd}" "${totsub}" "${LGPFX}flow\t (${totflowd}) should download same number of files as ${LGPFX}subscribe downloads (${totsub})"
-zerowanted "${missed_dispositions}" "${maxshovel}" "messages received that we don't know what happened."
+zerowanted "${missed_dispositions}" "${bulletin_count}" "messages received that we don't know what happened."
 
 if [ "$MQP" == "amqp" ]; then
-    zerowanted  "${messages_unacked}" "${maxshovel}" "there should be no unacknowledged messages left, but there are ${messages_unacked}"
-    zerowanted  "${messages_ready}" "${maxshovel}" "there should be no messages ready to be consumed but there are ${messages_ready}"
+    zerowanted  "${messages_unacked}" "${bulletin_count}" "there should be no unacknowledged messages left, but there are ${messages_unacked}"
+    zerowanted  "${messages_ready}" "${bulletin_count}" "there should be no messages ready to be consumed but there are ${messages_ready}"
 fi
 
 echo "Overall ${flow_test_name} ${passedno} of ${tno} passed (sample size: $staticfilecount) !"

--- a/am_flow/flow_include.sh
+++ b/am_flow/flow_include.sh
@@ -241,3 +241,5 @@ function countall {
 
 messages_unacked="`rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} list queues name messages_unacknowledged | awk ' BEGIN {t=0;} (NR > 1)  && /_f[0-9][0-9]/ { t+=$4; }; END { print t; };'`"
 messages_ready="`rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} list queues name messages_ready | awk ' BEGIN {t=0;} (NR > 1)  && /_f[0-9][0-9]/ { t+=$4; }; END { print t; };'`"
+
+bulletin_count="`find ${SAMPLEDATA}/20200105/WXO-DD/bulletins/alphanumeric/* | wc -l`"

--- a/flow_utils.sh
+++ b/flow_utils.sh
@@ -25,6 +25,7 @@ export TESTDIR="`pwd`"
 SAMPLEDATA="`dirname $TESTDIR`"
 export SAMPLEDATA=${SAMPLEDATA}/samples/data
 
+
 SR_TEST_CONFIGS=${TESTDIR}/config
 
 CONFIG_COUNT="`find ${SR_TEST_CONFIGS} -type f -name '*.conf' | wc -l`"
@@ -232,3 +233,6 @@ missedreport="$LOGDIR/missed_dispositions.report"
 trivialhttplog="$LOGDIR/trivialhttpserver_f00.log"
 trivialftplog="$LOGDIR/trivialftpserver_f00.log"
 trivialupstreamhttplog="$LOGDIR/trivialupstreamhttpserver_f00.log"
+
+
+MQP="`grep -v '^#' ~/.config/sr3/default.conf | grep 'declare env MQP=' | sed 's/.*MQP=//'`"


### PR DESCRIPTION
- The AM flow tests should now be executable from any machine.
- I got them to work from 2 Ubuntu 22.04 servers and an Ubuntu 18.04 server. Haven't tested Ubuntu 20.04.
- There were a couple of hard coded paths, and some left over configurations that needed tweaking.

- Ocasionally there will be unack'ed messages on the flow component, however running the tests a second time usually makes that problem go away.


