### PR TITLE
remove v2 configs after conversion is done in sr3 flow tests

### DIFF
--- a/static_flow/flow_setup.sh
+++ b/static_flow/flow_setup.sh
@@ -74,6 +74,10 @@ if [ "$1" != "skipconfig" ]; then
             sr3 convert $i
         done
      fi
+     for c in ${flow_configs}; do
+	 echo rm ${HOME}/.config/sarra/${c}
+	 rm ${HOME}/.config/sarra/${c}
+     done
    fi
 
    if [ "$1" == "config" ]; then


### PR DESCRIPTION

I noticed that when you run v2 flow tests... the way it works is:
* install v2 configs.
* run convert to get sr3 ones.
* run the sr3 tests...

This leaves the v2 configs populated with a tree of files.  If you are running multiple tests,
then after a while the v2 configs could include leftovers of multiple tests, and things can get 
quite confusing.

This snippet removes all the v2 configs as soon as the sr3 convert has completed. should be cleaner.
