### PR TITLE
adding totpoll_unique to better reflect unique files & dirs posted

### DIFF
--- a/flakey_broker/flow_check.sh
+++ b/flakey_broker/flow_check.sh
@@ -223,9 +223,9 @@ calcres ${totsubu}    ${totsent}    "${LGPFX}subscribe u_sftp_f60 (${totsubu}) s
 calcres ${totsubcp}   ${totsent}    "${LGPFX}subscribe cp_f61\t (${totsubcp}) should have the same number of items as ${LGPFX}sender (${totsent})"
 echo "                 | poll       routing |"
 printf " poll sftp_f62 posted $totpoll2  sftp_f63 posted $totpoll3 \n" 
-calcres ${totpoll}   ${totsent}         "${LGPFX}poll sftp_f62+3\t (${totpoll}) should have the same number of items of ${LGPFX}sender\t (${totsent})"
+calcres ${totpoll_unique}   ${totsent}         "${LGPFX}poll sftp_f62+3\t (${totpoll_unique}) should have the same number of items of ${LGPFX}sender\t (${totsent})"
 if [ "${totpoll_mirrored}" ]; then
-    calcres "${totpoll}" "${totpoll_mirrored}" "${LGPFX}poll sftp_f62+3\t (${totpoll_mirrored}) should see the same number of items as ${LGPFX}poll sftp_f62 posted\t (${totpoll})"
+    calcres "${totpoll_unique}" "${totpoll_mirrored}" "${LGPFX}poll sftp_f62+3\t (${totpoll_mirrored}) should see the same number of items as ${LGPFX}poll sftp_f62 posted\t (${totpoll_unique})"
 fi
 
 calcres ${totsubq}    ${totpoll}   "${LGPFX}subscribe q_f71\t (${totsubq}) should have the same number of items as ${LGPFX}poll sftp_f62+3 (${totpoll})"

--- a/flakey_broker/flow_include.sh
+++ b/flakey_broker/flow_include.sh
@@ -280,12 +280,13 @@ function countall {
   totsubq="${tot}"
 
   if [ "${sarra_py_version:0:1}" == "3" ]; then
-       countthem "`grep -aE 'log after_post posted' "$LOGDIR"/${LGPFX}poll_sftp_f62_*.log | wc -l`"
+       countthem "`grep -aE 'log after_post posted' "$LOGDIR"/poll_sftp_f62_*.log | wc -l`"
        totpoll2="${tot}"
-       countthem "`grep -aE 'log after_post posted' "$LOGDIR"/${LGPFX}poll_sftp_f63_*.log | wc -l`"
+       countthem "`grep -aE 'log after_post posted' "$LOGDIR"/poll_sftp_f63_*.log | wc -l`"
        totpoll3="${tot}"
        totpoll=$(( ${totpoll2} + ${totpoll3} ))
-       totpoll_mirrored="`grep -a ', now saved' "$LOGDIR"/${LGPFX}poll_sftp_f6*_*.log | awk ' { print $18 } '|tail -1`"
+       totpoll_unique="`grep -aE 'log after_post posted' $LOGDIR/poll_sftp_f6?_*.log | awk '{ print $18; }' | sort -u | wc -l`"
+       totpoll_mirrored="`grep -a ', now saved' "$LOGDIR"/poll_sftp_f6*_*.log | awk ' { print $18 } '|tail -1`"
   else
        countthem "`grep -aE '\[INFO\] post_log' "$LOGDIR"/${LGPFX}poll_sftp_f62_*.log | wc -l`"
        totpoll2="${tot}"


### PR DESCRIPTION

The flakey_broker tests are always failing with the sftp_polls, but the resulting trees are identical.  It is normal that when a broker is shutdown unexpectedly that some messages get dropped (aka published and not acknowledged.) so the important thing to figure out is how different many files and directories were published by the polls taken together.  If every single file and directory was posted, then the polls worked.  The extra posts are just a normal consequence of the broker failing (the whole point of the test.)

So added a new variable in flakey_broker/flow_include.sh  where it looks for all the files & directories posted, and then runs them through sort -u.  If we missed some, this total should be short.  But it isn't so the tests should pass.
