### PR TITLE
add duplicate suppression to post because

### DIFF
--- a/flakey_broker/config/post/test2_f61.conf
+++ b/flakey_broker/config/post/test2_f61.conf
@@ -8,6 +8,7 @@ post_exchange_suffix post
 post_base_dir   ${TESTDOCROOT}
 post_base_url   ftp://anonymous@localhost:2121
 
+nodupe_ttl 600
 set sarracenia.moth.amqp.AMQP.logLevel info
 set sarracenia.moth.mqtt.MQTT.logLevel info
 


### PR DESCRIPTION
wrong counts were getting reports flakey_broker tests failing with mismatches.  Adding duplicate suppression makes the totals the same.

symptom... flakey_broker tests failing like so:

```
test 23 FAILURE: post test2_f61  (1447) should have the same number of files of sender   (1111)
test 24 FAILURE: subscribe ftp_f70       (1111) should have the same number of items as post test2_f61 (1447)
test 25 FAILURE: post test2_f61  (1447) should post about the same number of files as shim_f63   (1111)
test 26 FAILURE: post test2_f61  (1447) should post about the same number of links as shim_f63   (1111)

```
