### PR TITLE
only post quiescent files

### DIFF
--- a/flakey_broker/config/post/test2_f61.conf
+++ b/flakey_broker/config/post/test2_f61.conf
@@ -8,6 +8,7 @@ post_exchange_suffix post
 post_base_dir   ${TESTDOCROOT}
 post_base_url   ftp://anonymous@localhost:2121
 
+inflight 20
 nodupe_ttl 600
 set sarracenia.moth.amqp.AMQP.logLevel info
 set sarracenia.moth.mqtt.MQTT.logLevel info


### PR DESCRIPTION
I think this fixes the four tests failing in a lot of flakey runs (especially on slower hw)

```
test 23 FAILURE: post test2_f61  (1555) should have the same number of files of sender   (1125)
test 24 FAILURE: subscribe ftp_f70       (1125) should have the same number of items as post test2_f61 (1555)
test 25 FAILURE: post test2_f61  (1555) should post about the same number of files as shim_f63   (1125)
test 26 FAILURE: post test2_f61  (1555) should post about the same number of links as shim_f63   (1125)

```
