### PR TITLE
mark the end of sr3 dynamic flow test (so it does not report negative…

### DIFF
--- a/dynamic_flow/flow_limit3.sh
+++ b/dynamic_flow/flow_limit3.sh
@@ -129,5 +129,7 @@ echo "No messages left in queues... wait 2* maximum heartbeat ( ${need_to_wait} 
 
 sleep ${need_to_wait}
 
+date +'%s' >"${LOGDIR}/timestamp_end.txt"
+
 printf "\n\nflow test ${flow_test_name} v3 stopped at $totsarra (limit: $smin)\n\n"
 


### PR DESCRIPTION

```
 cclean_f91    (550) should have deleted as many files as went through van     (550)
test 33 success: veille_f34 should post as many files (1105} as went through van (550) and clean  (550))
test 34 success: veille_f34 should post twice as many files (1105) as subscribe cdnld_f21 downloaded (550)
test 35 success: veille_f34 should post twice as many files (1105) as subscribe cfile_f44 downloaded (557)
test 36 success: zero broker unacknowledged messages
test 37 success: zero broker messages ready to be consumed (queued but not consumed)
test 38 success: Overall dynamic_flow 37 of 37 passed (sample size: 539) !

cat: /home/peter/.cache/sr3/log/timestamp_end.txt: No such file or directory
test ran for -1774390915 seconds
idefix% git status

```

test ran for -177 bajillion seconds? 

fix that.