### PR TITLE
Wait for post test2_f61 to finish posting

### DIFF
--- a/flakey_broker/config/post/test2_f61.conf
+++ b/flakey_broker/config/post/test2_f61.conf
@@ -17,3 +17,5 @@ set sarracenia.moth.mqtt.MQTT.logLevel info
 accept          .*
 
 retryEmptyBeforeExit True
+
+loglevel debug

--- a/flakey_broker/config/sender/tsource2send_f50.conf
+++ b/flakey_broker/config/sender/tsource2send_f50.conf
@@ -34,3 +34,5 @@ post_broker ${MQP}://tsource@${FLOWBROKER}
 post_exchange_suffix output
 
 accept .*
+
+loglevel debug

--- a/flakey_broker/flow_limit.sh
+++ b/flakey_broker/flow_limit.sh
@@ -127,8 +127,6 @@ while [ $retry_msgcnt -gt 0 ]; do
 
 done
 
-# wait for post
-
 #queued_msgcnt="`rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -f tsv list queues | awk ' BEGIN {t=0;} (NR > 1)  && /_f[0-9][0-9]/ { t+=$(23); }; END { print t; };'`"
 queued_msgcnt="`rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -f tsv list queues | awk ' BEGIN {t=0;} (NR > 1)  && /_f[0-9][0-9]/ { t+=$2; }; END { print t; };'`"
 while [ $queued_msgcnt -gt 0 ]; do

--- a/flakey_broker/flow_limit.sh
+++ b/flakey_broker/flow_limit.sh
@@ -99,7 +99,7 @@ running=1
 count=0
 while [ $running -gt 0 ]; do
   # can have sr_post or sr3_post
-  running="`ps ax | grep -aE '(sr_post|sr3_post)' | grep t_dd | wc -l`"
+  running="`ps ax | grep -aE '(sr_post|sr3_post)' | grep -E "t_dd|test2_f61" | wc -l`"
   printf "${flow_test_name} ${running} processes still posting... %d\n" $count
   count=$((${count}+1))
   sleep 10
@@ -126,6 +126,8 @@ while [ $retry_msgcnt -gt 0 ]; do
         fi
 
 done
+
+# wait for post
 
 #queued_msgcnt="`rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -f tsv list queues | awk ' BEGIN {t=0;} (NR > 1)  && /_f[0-9][0-9]/ { t+=$(23); }; END { print t; };'`"
 queued_msgcnt="`rabbitmqadmin -H localhost -u bunnymaster -p ${adminpw} -f tsv list queues | awk ' BEGIN {t=0;} (NR > 1)  && /_f[0-9][0-9]/ { t+=$2; }; END { print t; };'`"


### PR DESCRIPTION
This waits for `test2_f61` to terminate before proceeding. This really isn't 100% necessary, because the code right after the change waits for retries to finish, and test2_f61 will have retry files on disk until it finishes posting. But I still think it's a good change.